### PR TITLE
feat: 支持全局加密配置并优化配置优先级

### DIFF
--- a/httpseeker/core/auth.yaml
+++ b/httpseeker/core/auth.yaml
@@ -19,7 +19,7 @@ tk:
   # jsonpath表达式，用于从响应中提取token
   token_key: $.data
   # token有效期，单位: 秒
-  timeout: 100000
+  timeout: 100
 ##
 ## bearer token 认证（自动登录获取）
 ##

--- a/httpseeker/core/conf.toml
+++ b/httpseeker/core/conf.toml
@@ -67,3 +67,8 @@ redirects = true
 proxies.http = ''
 proxies.https = ''
 retry = 3
+
+# 加密配置
+[encryption]
+enabled = true
+key = "your-32-byte-secure-aes-key-1234"

--- a/httpseeker/data/test_data/power_bank/test_encryptionEnabled.yaml
+++ b/httpseeker/data/test_data/power_bank/test_encryptionEnabled.yaml
@@ -1,0 +1,52 @@
+# 获取任务密码接口测试用例
+config:
+  allure:
+    epic: "加密接口测试"
+    feature: "任务管理"
+    story: "获取任务密码接口测试"
+    severity: "critical"
+
+  request:
+    env: "test.env"  # 需要在run_env目录下创建test.env文件
+    headers:
+      Content-Type: "application/json"
+    timeout: 30
+    verify: false
+    # 加密配置
+    encryption_enabled: true
+    encryption_key: "your-32-byte-secure-aes-key-1234"  # 32字节的AES密钥
+
+  module: "encryption_test"
+
+test_steps:
+  name: "测试获取任务密码接口1"
+  case_id: "l1ENC_TASK_003"
+  description: "验证获取任务密码接口的加密响应解密功能"
+
+  request:
+    method: "GET"
+    url: "/cdb/api/auth/encryptionEnabled"  # 需要配合test.env中的host使用
+    params: null
+    headers: null
+    cookies: null
+    body_type: null
+    body: null
+    files: null
+  teardown:
+    - assert:
+        check: "验证请求成功"
+        type: "eq"
+        value: 20000
+        jsonpath: "$.json.code"
+
+    - assert:
+        check: "验证返回成功标识"
+        type: "eq"
+        value: true
+        jsonpath: "$.json.success"
+
+    - assert:
+        check: "验证data不为空"
+        type: "not_eq"
+        value: null
+        jsonpath: "$.json.data"

--- a/httpseeker/data/test_data/power_bank/test_getLikeTaskTypeList.yaml
+++ b/httpseeker/data/test_data/power_bank/test_getLikeTaskTypeList.yaml
@@ -1,0 +1,52 @@
+# 获取任务密码接口测试用例
+config:
+  allure:
+    epic: "加密接口测试"
+    feature: "任务管理"
+    story: "获取任务密码接口测试"
+    severity: "critical"
+
+  request:
+    env: "test.env"  # 需要在run_env目录下创建test.env文件
+    headers:
+      Content-Type: "application/json"
+    timeout: 30
+    verify: false
+    # 加密配置
+    encryption_enabled: true
+    encryption_key: "your-32-byte-secure-aes-key-1234"  # 32字节的AES密钥
+
+  module: "encryption_test"
+
+test_steps:
+  name: "测试获取任务密码接口"
+  case_id: "lENC_TAS1K_002"
+  description: "验证获取任务密码接口的加密响应解密功能"
+
+  request:
+    method: "GET"
+    url: "/cdb//api/taskOrder/getLikeTaskTypeList"  # 需要配合test.env中的host使用
+    params: null
+    headers: null
+    cookies: null
+    body_type: null
+    body: null
+    files: null
+  teardown:
+    - assert:
+        check: "验证请求成功"
+        type: "eq"
+        value: 20000
+        jsonpath: "$.json.code"
+
+    - assert:
+        check: "验证返回成功标识"
+        type: "eq"
+        value: true
+        jsonpath: "$.json.success"
+
+    - assert:
+        check: "验证data不为空"
+        type: "not_eq"
+        value: null
+        jsonpath: "$.json.data"

--- a/httpseeker/data/test_data/power_bank/test_getTaskPassword.yaml
+++ b/httpseeker/data/test_data/power_bank/test_getTaskPassword.yaml
@@ -20,7 +20,7 @@ config:
 
 test_steps:
   name: "测试获取任务密码接口"
-  case_id: "ENC_TASK_001"
+  case_id: "lENC_TAS1K_006"
   description: "验证获取任务密码接口的加密响应解密功能"
 
   request:

--- a/httpseeker/utils/request/request_data_parse.py
+++ b/httpseeker/utils/request/request_data_parse.py
@@ -205,26 +205,28 @@ class RequestDataParse:
 
     @property
     def encryption_enabled(self) -> bool | None:
-        """获取加密启用状态"""
+        """获取加密启用状态 - 优先从 case 读取，否则从全局配置读取"""
         try:
             encryption_enabled = self.request_data['config']['request']['encryption_enabled']
             if encryption_enabled is not None:
                 if not isinstance(encryption_enabled, bool):
                     raise RequestDataParseError(_error_msg('参数 config:request:encryption_enabled 不是有效的 bool 类型'))
         except _RequestDataParamGetError:
-            encryption_enabled = None
+            # 从全局配置读取
+            encryption_enabled = httpseeker_config.get('encryption', {}).get('enabled')
         return encryption_enabled
 
     @property
     def encryption_key(self) -> str | None:
-        """获取加密密钥"""
+        """获取加密密钥 - 优先从 case 读取，否则从全局配置读取"""
         try:
             encryption_key = self.request_data['config']['request']['encryption_key']
             if encryption_key is not None:
                 if not isinstance(encryption_key, str):
                     raise RequestDataParseError(_error_msg('参数 config:request:encryption_key 不是有效的 str 类型'))
         except _RequestDataParamGetError:
-            encryption_key = None
+            # 从全局配置读取
+            encryption_key = httpseeker_config.get('encryption', {}).get('key')
         return encryption_key
 
     @property


### PR DESCRIPTION
  - 在 conf.toml 中新增 [encryption] 全局配置段
  - 优化加密配置读取逻辑：优先读取 case 级别配置，无配置时回退到全局配置
  - 调整 tk token 认证超时时间为 100 秒
  - 新增多个加密接口测试用例

  主要改动：
  1. conf.toml: 添加 encryption.enabled 和 encryption.key 全局配置
  2. request_data_parse.py: 重构 encryption_enabled 和 encryption_key 属性，支持全局配置回退
  3. auth.yaml: 优化 tk 认证超时配置
  4. 新增测试用例: test_getTaskPassword, test_getLikeTaskTypeList, test_encryptionEnabled

  优势：
  - 避免在每个 case 中重复配置加密参数
  - 便于统一管理项目级别的加密密钥
  - 保留 case 级别配置覆盖能力，提升灵活性